### PR TITLE
Add a "Protect your pages" step (server-side auth read)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -21,6 +21,7 @@ const { title } = Astro.props
           <SignInButton mode="modal" />
         </Show>
         <Show when="signed-in">
+          <a href="/protected">Protected</a>
           <UserButton />
         </Show>
       </nav>

--- a/src/pages/protected.astro
+++ b/src/pages/protected.astro
@@ -1,0 +1,16 @@
+---
+import Layout from '../layouts/Layout.astro'
+
+// Use `auth()` to read the session on the server and protect this page.
+// Unlike the `<Show>` component, which only controls what renders, this is
+// the real access check: a signed-out user who navigates here is redirected.
+const { isAuthenticated, userId } = Astro.locals.auth()
+
+if (!isAuthenticated) {
+  return Astro.redirect('/')
+}
+---
+
+<Layout title="Protected">
+  <p>Welcome! Your user ID is <code>{userId}</code>.</p>
+</Layout>


### PR DESCRIPTION
## Summary

Adds a `/protected` route to the quickstart that reads the signed-in user on the **server** and redirects signed-out visitors to `/`, plus a **"Protected"** nav link shown only when signed in.

## Why

The quickstart currently ends at client-side UI (`<SignInButton>`, `<UserButton>`, `<SignedIn>`). This adds the missing half — reading the authenticated user in your own server code — and makes the model explicit:

> **Client components control visibility. The server controls access.**

It mirrors the pattern already shipped in the TanStack React Start quickstart.

## What's here

- A `/protected` route using this SDK's server-side auth helper, redirecting signed-out users to `/` and rendering the user's ID when signed in.
- A "Protected" link in the header, gated by `<SignedIn>`.

## Verification

Booted with real Clerk keys: signed-out `/protected` redirects to `/`; signed-in renders the user's ID. Type-checks clean.

Part of DOCS-11853.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Companion PRs

- **clerk-nextjs-app-quickstart**: https://github.com/clerk/clerk-nextjs-app-quickstart/pull/40
- **clerk-nextjs-pages-quickstart**: https://github.com/clerk/clerk-nextjs-pages-quickstart/pull/16
- **clerk-nuxt-quickstart**: https://github.com/clerk/clerk-nuxt-quickstart/pull/13
- **clerk-react-router-quickstart**: https://github.com/clerk/clerk-react-router-quickstart/pull/12
