### PR TITLE
fix: resolve TypeScript errors in src/api/example.ts

### DIFF
--- a/src/api/example.ts
+++ b/src/api/example.ts
@@ -1,6 +1,7 @@
 import { clerkClient } from '@clerk/astro/server'
+import type { APIContext } from 'astro'
 
-export async function GET(context) {
+export async function GET(context: APIContext) {
   // The `Auth` object gives you access to properties like `isAuthenticated` and `userId`
   // Accessing the `Auth` object differs depending on the SDK you're using
   // https://clerk.com/docs/references/backend/types/auth-object#how-to-access-the-auth-object
@@ -16,7 +17,7 @@ export async function GET(context) {
   // Use the Backend SDK to get the user's OAuth access token
   const clerkResponse = await clerkClient(context).users.getUserOauthAccessToken(userId, provider)
 
-  const accessToken = clerkResponse[0].token || ''
+  const accessToken = clerkResponse.data[0].token || ''
 
   if (!accessToken) {
     return new Response('Access token not found', { status: 401 })


### PR DESCRIPTION
## Summary

`astro check` was red on `main` due to two pre-existing TypeScript errors in `src/api/example.ts`, unrelated to any feature work. This fixes both so the type check passes cleanly.

## Changes

- Type the API route's `context` parameter as `APIContext` from `astro` (resolves `ts(7006)` — implicitly `any`).
- Read the OAuth access token via `clerkResponse.data[0].token` instead of `clerkResponse[0].token` (resolves `ts(7053)`). `getUserOauthAccessToken()` returns a `PaginatedResourceResponse<OauthAccessToken[]>`, whose payload lives on `.data` — confirmed against `@clerk/backend`'s `deserialize()`, which always wraps responses as `{ data, ... }`. The old top-level index was also a latent runtime bug (`clerkResponse[0]` is `undefined`).

## References

- [DOCS-11863](https://linear.app/clerk/issue/DOCS-11863/clerk-astro-quickstart-2-typescript-errors-in-srcapiexamplets)
- Surfaced while verifying [DOCS-11853](https://linear.app/clerk/issue/DOCS-11853) (#16); these errors are independent of that work.
